### PR TITLE
introduce expr/constant into fdSet with uniqueID and refine some op's logic

### DIFF
--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -4245,7 +4245,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 	return result, nil
 }
 
-func (ds *DataSource) extractFD() *fd.FDSet {
+func (ds *DataSource) ExtractFD() *fd.FDSet {
 	// FD in datasource (leaf node) can be cached and reused.
 	if ds.fdSet == nil {
 		fds := &fd.FDSet{}

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -316,7 +316,7 @@ func (p *LogicalProjection) ExtractFD() *fd.FDSet {
 	// collect the output columns' unique ID.
 	outputColsUniqueIDs := fd.NewFastIntSet()
 	notnullColsUniqueIDs := fd.NewFastIntSet()
-	outputColsUniqueIDsArray := make([]int, len(p.Schema().Columns))
+	outputColsUniqueIDsArray := make([]int, 0, len(p.Schema().Columns))
 	// here schema extended columns may contain expr, const and column allocated with uniqueID.
 	for _, one := range p.Schema().Columns {
 		outputColsUniqueIDs.Insert(int(one.UniqueID))
@@ -371,6 +371,8 @@ func (p *LogicalProjection) ExtractFD() *fd.FDSet {
 	// since the distinct attribute is built as firstRow agg func, we don't need to think about it here.
 	fds.MakeNotNull(notnullColsUniqueIDs)
 	fds.ProjectCols(outputColsUniqueIDs)
+	// just trace it down in every operator for test checking.
+	p.fdSet = fds
 	return fds
 }
 
@@ -488,6 +490,8 @@ func (la *LogicalAggregation) ExtractFD() *fd.FDSet {
 			fds.AddStrictFunctionalDependency(groupByColsUniqueIDs, outputColsUniqueIDs)
 		}
 	}
+	// just trace it down in every operator for test checking.
+	la.fdSet = fds
 	return fds
 }
 
@@ -691,6 +695,8 @@ func (p *LogicalSelection) ExtractFD() *fd.FDSet {
 		fds.AddEquivalence(equiv[0], equiv[1])
 	}
 	fds.ProjectCols(outputColsUniqueIDs)
+	// just trace it down in every operator for test checking.
+	p.fdSet = fds
 	return fds
 }
 

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -633,7 +633,7 @@ func (p *LogicalSelection) ExtractFD() *fd.FDSet {
 	// eg: where a=1 and b is null and (1+c)=5.
 	// TODO: Some columns can only be determined to be constant from multiple constraints (e.g. x <= 1 AND x >= 1)
 	var (
-		constObjs      []interface{}
+		constObjs      []expression.Expression
 		constUniqueIDs = fd.NewFastIntSet()
 	)
 	constObjs = expression.ExtractConstantEqColumnsOrScalar(p.ctx, constObjs, p.Conditions)
@@ -654,7 +654,7 @@ func (p *LogicalSelection) ExtractFD() *fd.FDSet {
 	}
 
 	// extract equivalence cols.
-	var equivObjsPair [][]interface{}
+	var equivObjsPair [][]expression.Expression
 	equivObjsPair = expression.ExtractEquivalenceColumns(equivObjsPair, p.Conditions)
 	equivUniqueIDs := make([][]fd.FastIntSet, 0, len(equivObjsPair))
 	for _, equivObjPair := range equivObjsPair {

--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -375,6 +375,11 @@ func enableParallelApply(sctx sessionctx.Context, plan PhysicalPlan) PhysicalPla
 	return plan
 }
 
+// LogicalOptimize is just exported for test.
+func LogicalOptimize(ctx context.Context, flag uint64, logic LogicalPlan) (LogicalPlan, error) {
+	return logicalOptimize(ctx, flag, logic)
+}
+
 func logicalOptimize(ctx context.Context, flag uint64, logic LogicalPlan) (LogicalPlan, error) {
 	opt := defaultLogicalOptimizeOption()
 	vars := logic.SCtx().GetSessionVars()

--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -375,8 +375,8 @@ func enableParallelApply(sctx sessionctx.Context, plan PhysicalPlan) PhysicalPla
 	return plan
 }
 
-// LogicalOptimize is just exported for test.
-func LogicalOptimize(ctx context.Context, flag uint64, logic LogicalPlan) (LogicalPlan, error) {
+// LogicalOptimizeTest is just exported for test.
+func LogicalOptimizeTest(ctx context.Context, flag uint64, logic LogicalPlan) (LogicalPlan, error) {
 	return logicalOptimize(ctx, flag, logic)
 }
 

--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -314,8 +314,8 @@ type LogicalPlan interface {
 	// buildLogicalPlanTrace clone necessary information from LogicalPlan
 	buildLogicalPlanTrace(p Plan) *tracing.LogicalPlanTrace
 
-	// extractFD derive the FDSet from the tree bottom up.
-	extractFD() *fd.FDSet
+	// ExtractFD derive the FDSet from the tree bottom up.
+	ExtractFD() *fd.FDSet
 }
 
 // PhysicalPlan is a tree of the physical operators.
@@ -384,11 +384,11 @@ type baseLogicalPlan struct {
 	fdSet *fd.FDSet
 }
 
-// extractFD return the children[0]'s fdSet if there are no adding/removing fd in this logic plan.
-func (p *baseLogicalPlan) extractFD() *fd.FDSet {
+// ExtractFD return the children[0]'s fdSet if there are no adding/removing fd in this logic plan.
+func (p *baseLogicalPlan) ExtractFD() *fd.FDSet {
 	fds := &fd.FDSet{}
 	for _, ch := range p.children {
-		fds.AddFrom(ch.extractFD())
+		fds.AddFrom(ch.ExtractFD())
 	}
 	return fds
 }

--- a/planner/core/stringer.go
+++ b/planner/core/stringer.go
@@ -28,6 +28,12 @@ func ToString(p Plan) string {
 	return strings.Join(strs, "->")
 }
 
+// FDToString explains fd transfer over a Plan, returns description string.
+func FDToString(p LogicalPlan) string {
+	strs, _ := fdToString(p, []string{}, []int{})
+	return strings.Join(strs, " >>> ")
+}
+
 func needIncludeChildrenString(plan Plan) bool {
 	switch x := plan.(type) {
 	case *LogicalUnionAll, *PhysicalUnionAll, *LogicalPartitionUnionAll:
@@ -41,6 +47,25 @@ func needIncludeChildrenString(plan Plan) bool {
 	default:
 		return false
 	}
+}
+
+func fdToString(in LogicalPlan, strs []string, idxs []int) ([]string, []int) {
+	switch x := in.(type) {
+	case *LogicalProjection:
+		strs = append(strs, "{"+x.fdSet.String()+"}")
+		for i := 0; i < x.ChildrenCount(); i++ {
+			strs, idxs = fdToString(x.GetChild(i), strs, idxs)
+		}
+	case *LogicalAggregation:
+		strs = append(strs, "{"+x.fdSet.String()+"}")
+		for i := 0; i < x.ChildrenCount(); i++ {
+			strs, idxs = fdToString(x.GetChild(i), strs, idxs)
+		}
+	case *DataSource:
+		strs = append(strs, "{"+x.fdSet.String()+"}")
+	default:
+	}
+	return strs, idxs
 }
 
 func toString(in Plan, strs []string, idxs []int) ([]string, []int) {

--- a/planner/core/stringer.go
+++ b/planner/core/stringer.go
@@ -17,6 +17,7 @@ package core
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/pingcap/tidb/util/plancodec"
@@ -31,6 +32,9 @@ func ToString(p Plan) string {
 // FDToString explains fd transfer over a Plan, returns description string.
 func FDToString(p LogicalPlan) string {
 	strs, _ := fdToString(p, []string{}, []int{})
+	sort.SliceStable(strs, func(i, j int) bool {
+		return true
+	})
 	return strings.Join(strs, " >>> ")
 }
 

--- a/planner/functional_dependency/extract_fd_test.go
+++ b/planner/functional_dependency/extract_fd_test.go
@@ -45,30 +45,41 @@ func TestFDSet_ExtractFD(t *testing.T) {
 		{
 			sql:  "select a from t1",
 			best: "DataScan(t1)->Projection",
-			fd:   "{} >>> {(1)-->(2,3), (2,3)~~>(1)}",
+			fd:   "{(1)-->(2,3), (2,3)~~>(1)} >>> {}",
 		},
 		{
 			sql:  "select a,b from t1",
 			best: "DataScan(t1)->Projection",
-			fd:   "{(1)-->(2)} >>> {(1)-->(2,3), (2,3)~~>(1)}",
+			fd:   "{(1)-->(2,3), (2,3)~~>(1)} >>> {(1)-->(2)}",
 		},
 		{
 			sql:  "select a,c,b+1 from t1",
 			best: "DataScan(t1)->Projection",
 			// 4 is the extended column from (b+1) determined by b, also determined by a.
-			fd: "{(1)-->(3,4)} >>> {(1)-->(2,3), (2,3)~~>(1)}",
+			fd: "{(1)-->(2,3), (2,3)~~>(1)} >>> {(1)-->(3,4)}",
 		},
 		{
 			sql:  "select a,b+1,c+b from t1",
 			best: "DataScan(t1)->Projection",
 			// 4, 5 is the extended column from (b+1),(c+b) determined by b,c, also determined by a.
-			fd: "{(1)-->(4,5)} >>> {(1)-->(2,3), (2,3)~~>(1)}",
+			fd: "{(1)-->(2,3), (2,3)~~>(1)} >>> {(1)-->(4,5)}",
 		},
 		{
 			sql:  "select a,a+b,1 from t1",
 			best: "DataScan(t1)->Projection",
 			// 4 is the extended column from (b+1) determined by b, also determined by a.
-			fd: "{(1)-->(4), ()-->(5)} >>> {(1)-->(2,3), (2,3)~~>(1)}",
+			fd: "{(1)-->(2,3), (2,3)~~>(1)} >>> {(1)-->(4), ()-->(5)}",
+		},
+		{
+			sql: "select b+1, sum(a) from t1 group by(b)",
+			// since b is projected out, b --> b+1 and b ~~> sum(a) is eliminated.
+			best: "DataScan(t1)->Aggr(sum(test.t1.a),firstrow(test.t1.b))->Projection",
+			fd:   "{(1)-->(2,3), (2,3)~~>(1)} >>> {(2)~~>(4)} >>> {}",
+		},
+		{
+			sql:  "select b+1, b, sum(a) from t1 group by(b)",
+			best: "DataScan(t1)->Aggr(sum(test.t1.a),firstrow(test.t1.b))->Projection",
+			fd:   "{(1)-->(2,3), (2,3)~~>(1)} >>> {(2)~~>(4)} >>> {(2)~~>(4), (2)-->(5)}",
 		},
 	}
 
@@ -87,7 +98,7 @@ func TestFDSet_ExtractFD(t *testing.T) {
 		ass.Nil(err)
 		p, err = plannercore.LogicalOptimize(ctx, builder.GetOptFlag(), p.(plannercore.LogicalPlan))
 		ass.Nil(err)
-		ass.Equal(plannercore.ToString(p), tt.best, comment)
+		ass.Equal(tt.best, plannercore.ToString(p), comment)
 		// extract FD to every OP
 		p.(plannercore.LogicalPlan).ExtractFD()
 		ass.Equal(tt.fd, plannercore.FDToString(p.(plannercore.LogicalPlan)), comment)

--- a/planner/functional_dependency/extract_fd_test.go
+++ b/planner/functional_dependency/extract_fd_test.go
@@ -36,6 +36,8 @@ func TestFDSet_ExtractFD(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t1(a int key, b int, c int, unique(b,c))")
 	tk.MustExec("create table t2(m int key, n int, p int, unique(m,n))")
+	tk.MustExec("create table x1(a int not null primary key, b int not null, c int default null, d int not null, unique key I_b_c (b,c), unique key I_b_d (b,d))")
+	tk.MustExec("create table x2(a int not null primary key, b int not null, c int default null, d int not null, unique key I_b_c (b,c), unique key I_b_d (b,d))")
 
 	tests := []struct {
 		sql  string
@@ -56,30 +58,92 @@ func TestFDSet_ExtractFD(t *testing.T) {
 			sql:  "select a,c,b+1 from t1",
 			best: "DataScan(t1)->Projection",
 			// 4 is the extended column from (b+1) determined by b, also determined by a.
-			fd: "{(1)-->(2,3), (2,3)~~>(1)} >>> {(1)-->(3,4)}",
+			// since b is also projected in the b+1, so 2 is kept.
+			fd: "{(1)-->(2,3), (2,3)~~>(1)} >>> {(1)-->(2,3), (2,3)~~>(1), (2)-->(4)}",
 		},
 		{
 			sql:  "select a,b+1,c+b from t1",
 			best: "DataScan(t1)->Projection",
 			// 4, 5 is the extended column from (b+1),(c+b) determined by b,c, also determined by a.
-			fd: "{(1)-->(2,3), (2,3)~~>(1)} >>> {(1)-->(4,5)}",
+			fd: "{(1)-->(2,3), (2,3)~~>(1)} >>> {(1)-->(2,3), (2,3)~~>(1), (2)-->(4), (2,3)-->(5)}",
 		},
 		{
 			sql:  "select a,a+b,1 from t1",
 			best: "DataScan(t1)->Projection",
 			// 4 is the extended column from (b+1) determined by b, also determined by a.
-			fd: "{(1)-->(2,3), (2,3)~~>(1)} >>> {(1)-->(4), ()-->(5)}",
+			fd: "{(1)-->(2,3), (2,3)~~>(1)} >>> {(1)-->(2,4), ()-->(5)}",
 		},
 		{
 			sql: "select b+1, sum(a) from t1 group by(b)",
 			// since b is projected out, b --> b+1 and b ~~> sum(a) is eliminated.
 			best: "DataScan(t1)->Aggr(sum(test.t1.a),firstrow(test.t1.b))->Projection",
-			fd:   "{(1)-->(2,3), (2,3)~~>(1)} >>> {(2)~~>(4)} >>> {}",
+			fd:   "{(1)-->(2,3), (2,3)~~>(1)} >>> {(2)~~>(4)} >>> {(2)~~>(4), (2)-->(5)}",
 		},
 		{
 			sql:  "select b+1, b, sum(a) from t1 group by(b)",
 			best: "DataScan(t1)->Aggr(sum(test.t1.a),firstrow(test.t1.b))->Projection",
 			fd:   "{(1)-->(2,3), (2,3)~~>(1)} >>> {(2)~~>(4)} >>> {(2)~~>(4), (2)-->(5)}",
+		},
+		// test for table x1 and x2
+		{
+			sql:  "select a from x1 group by a,b,c",
+			best: "DataScan(x1)->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {}",
+		},
+		{
+			sql:  "select b from x1 group by b",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.b))->Projection",
+			// b --> b is natural existed, so it won't exist in fd.
+			fd: "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {} >>> {}",
+		},
+		{
+			sql:  "select b as e from x1 group by b",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.b))->Projection",
+			// b --> b is naturally existed, so it won't exist in fd.
+			fd: "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {} >>> {}",
+		},
+		{
+			sql:  "select b+c from x1 group by b+c",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.b),firstrow(test.x1.c))->Projection",
+			// avoid allocating unique ID 7 from fd temporarily, and substituted by unique ID 5
+			// attention:
+			// b+c is an expr assigned with new plan ID when building upper-layer projection.
+			// when extracting FD after build phase is done, we should be able to recognize a+b in lower-layer group by item with the same unique ID.
+			// that's why we introduce session variable MapHashCode2UniqueID4ExtendedCol in.
+			fd: "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(2,3)-->(5), (5)~~>(2,3)} >>> {(2,3)-->(5), (5)~~>(2,3)}",
+		},
+		{
+			sql:  "select b+c, min(a) from x1 group by b+c, b-c",
+			best: "DataScan(x1)->Aggr(min(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c))->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(2,3)-->(6,8), (6,8)~~>(2,3,5)} >>> {(2,3)-->(6)}",
+		},
+		{
+			sql:  "select b+c, min(a) from x1 group by b, c",
+			best: "DataScan(x1)->Aggr(min(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c))->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(2,3)~~>(5)} >>> {(2,3)~~>(5), (2,3)-->(6)}",
+		},
+		{
+			sql:  "select b+c from x1 group by b,c",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.b),firstrow(test.x1.c))->Projection",
+			// b --> b is naturally existed, so it won't exist in fd.
+			fd: "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {} >>> {(2,3)-->(5)}",
+		},
+		{
+			sql:  "select case b when 1 then c when 2 then d else d end from x1 group by b,c,d",
+			best: "DataScan(x1)->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(2,3)~~>(4), (2,4)-->(3,5)}",
+		},
+		{
+			// scalar sub query will be substituted with constant datum.
+			sql:  "select c > (select b from x1) from x1 group by c",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.c))->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {} >>> {(3)-->(15)}",
+		},
+		{
+			sql:  "select exists (select * from x1) from x1 group by d",
+			best: "DataScan(x1)->Aggr(firstrow(1))->Projection",
+			// 14 is added in the logicAgg pruning process cause all the columns of agg has been pruned.
+			fd: "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(4)~~>(14)} >>> {()-->(13)}",
 		},
 	}
 
@@ -93,7 +157,12 @@ func TestFDSet_ExtractFD(t *testing.T) {
 		tk.Session().GetSessionVars().PlanColumnID = 0
 		err = plannercore.Preprocess(tk.Session(), stmt, plannercore.WithPreprocessorReturn(&plannercore.PreprocessorReturn{InfoSchema: is}))
 		ass.Nil(err)
+		tk.Session().PrepareTSFuture(ctx)
 		builder, _ := plannercore.NewPlanBuilder().Init(tk.Session(), is, &hint.BlockHintProcessor{})
+		// extract FD to every OP
+		if tt.sql == "select exists (select * from x1) from x1 group by d" {
+			fmt.Println(1)
+		}
 		p, err := builder.Build(ctx, stmt)
 		ass.Nil(err)
 		p, err = plannercore.LogicalOptimizeTest(ctx, builder.GetOptFlag(), p.(plannercore.LogicalPlan))

--- a/planner/functional_dependency/extract_fd_test.go
+++ b/planner/functional_dependency/extract_fd_test.go
@@ -1,0 +1,68 @@
+package functional_dependency_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/infoschema"
+	"github.com/pingcap/tidb/parser"
+	plannercore "github.com/pingcap/tidb/planner/core"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/util/hint"
+	"github.com/stretchr/testify/assert"
+)
+
+func testGetIS(ass *assert.Assertions, ctx sessionctx.Context) infoschema.InfoSchema {
+	dom := domain.GetDomain(ctx)
+	// Make sure the table schema is the new schema.
+	err := dom.Reload()
+	ass.Nil(err)
+	return dom.InfoSchema()
+}
+
+func TestFDSet_ExtractFD(t *testing.T) {
+	t.Parallel()
+	ass := assert.New(t)
+
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	par := parser.New()
+	par.SetParserConfig(parser.ParserConfig{EnableWindowFunction: true, EnableStrictDoubleTypeCheck: true})
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1(a int key, b int, c int, unique(b,c))")
+	tk.MustExec("create table t2(m int key, n int, p int, unique(m,n))")
+
+	tests := []struct {
+		sql  string
+		best string
+		fd   string
+	}{
+		{
+			sql:  "select a from t1",
+			best: "DataScan(t1)->Projection",
+			fd:   "",
+		},
+	}
+
+	ctx := context.TODO()
+	is := testGetIS(ass, tk.Session())
+	for i, tt := range tests {
+		comment := fmt.Sprintf("case:%v sql:%s", i, tt.sql)
+		stmt, err := par.ParseOneStmt(tt.sql, "", "")
+		ass.Nil(err, comment)
+		err = plannercore.Preprocess(tk.Session(), stmt, plannercore.WithPreprocessorReturn(&plannercore.PreprocessorReturn{InfoSchema: is}))
+		ass.Nil(err)
+		builder, _ := plannercore.NewPlanBuilder().Init(tk.Session(), is, &hint.BlockHintProcessor{})
+		p, err := builder.Build(ctx, stmt)
+		ass.Nil(err)
+		p, err = plannercore.LogicalOptimize(ctx, builder.GetOptFlag(), p.(plannercore.LogicalPlan))
+		ass.Nil(err)
+		ass.Equal(plannercore.ToString(p), tt.best, comment)
+		ass.Equal(p.(plannercore.LogicalPlan).ExtractFD().String(), "")
+	}
+}

--- a/planner/functional_dependency/extract_fd_test.go
+++ b/planner/functional_dependency/extract_fd_test.go
@@ -96,7 +96,7 @@ func TestFDSet_ExtractFD(t *testing.T) {
 		builder, _ := plannercore.NewPlanBuilder().Init(tk.Session(), is, &hint.BlockHintProcessor{})
 		p, err := builder.Build(ctx, stmt)
 		ass.Nil(err)
-		p, err = plannercore.LogicalOptimize(ctx, builder.GetOptFlag(), p.(plannercore.LogicalPlan))
+		p, err = plannercore.LogicalOptimizeTest(ctx, builder.GetOptFlag(), p.(plannercore.LogicalPlan))
 		ass.Nil(err)
 		ass.Equal(tt.best, plannercore.ToString(p), comment)
 		// extract FD to every OP

--- a/planner/functional_dependency/fd_graph.go
+++ b/planner/functional_dependency/fd_graph.go
@@ -582,7 +582,7 @@ func (s *FDSet) MaxOneRow(cols FastIntSet) {
 // ProjectCols projects FDSet to the target columns
 // Formula:
 // Strict decomposition FD4A: If X −→ Y Z then X −→ Y and X −→ Z.
-// Lax decomposition FD4B: If X ~→ Y Z and I(R) is Y -definite then X ~→ Z.
+// Lax decomposition FD4B: If X ~→ Y Z and I(R) is Y-definite then X ~→ Z.
 func (s *FDSet) ProjectCols(cols FastIntSet) {
 	// **************************************** START LOOP 1 ********************************************
 	// Ensure the transitive relationship between remaining columns won't be lost.

--- a/planner/functional_dependency/fd_graph.go
+++ b/planner/functional_dependency/fd_graph.go
@@ -537,7 +537,7 @@ func (s *FDSet) AddFrom(fds *FDSet) {
 	} else {
 		for k, v := range fds.HashCodeToUniqueID {
 			if _, ok := s.HashCodeToUniqueID[k]; ok {
-				panic("shouldn't be here, children has same expr while register not only once")
+				panic("shouldn't be here, children has same expr while registered not only once")
 			}
 			s.HashCodeToUniqueID[k] = v
 		}

--- a/planner/functional_dependency/fd_graph_ported_test.go
+++ b/planner/functional_dependency/fd_graph_ported_test.go
@@ -86,7 +86,7 @@ func TestFuncDeps_ColsAreKey(t *testing.T) {
 		// we could put 2 and 3 together and use (2,3)~~>(1,4,5) and (1)==(10) to
 		// prove that (2,3) is a lax key. But this is only true when that constant
 		// value for 3 is not NULL. We would have to pass non-null information to
-		// the check. See #42731.
+		// the check.
 		{cols: NewFastIntSet(2, 11), strict: false, lax: false},
 	}
 

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -505,6 +505,9 @@ type SessionVars struct {
 	// PlanColumnID is the unique id for column when building plan.
 	PlanColumnID int64
 
+	// MapHashCode2UniqueID4ExtendedCol map the expr's hash code to specified unique ID.
+	MapHashCode2UniqueID4ExtendedCol map[string]int
+
 	// User is the user identity with which the session login.
 	User *auth.UserIdentity
 


### PR DESCRIPTION

Signed-off-by: ailinkid <314806019@qq.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. introduce expr/constant into fdSet with uniqueID allocated
2. extract constant/equivalence/notnull attribute from select condition
3. refine some logic about groupby/projection/datasource
4. add some test about extractFD's behavior

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

