### PR TITLE
planner: testing the ExtractFD just after the plan building phase

### DIFF
--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -318,7 +318,8 @@ type LogicalProjection struct {
 // ExtractFD implements the logical plan interface, extracting the FD from bottom up.
 func (p *LogicalProjection) ExtractFD() *fd.FDSet {
 	// basically extract the children's fdSet.
-	fds := p.logicalSchemaProducer.ExtractFD()
+	fds := &fd.FDSet{}
+	fds.CopyFrom(p.logicalSchemaProducer.ExtractFD())
 	// collect the output columns' unique ID.
 	outputColsUniqueIDs := fd.NewFastIntSet()
 	notnullColsUniqueIDs := fd.NewFastIntSet()
@@ -458,7 +459,8 @@ func (la *LogicalAggregation) HasOrderBy() bool {
 // depend on logicalAgg.ExtractFD() to finish the only_full_group_by checking problem rather than by 1 & 2.
 func (la *LogicalAggregation) ExtractFD() *fd.FDSet {
 	// basically extract the children's fdSet.
-	fds := la.logicalSchemaProducer.ExtractFD()
+	fds := &fd.FDSet{}
+	fds.CopyFrom(la.logicalSchemaProducer.ExtractFD())
 	// collect the output columns' unique ID.
 	outputColsUniqueIDs := fd.NewFastIntSet()
 	notnullColsUniqueIDs := fd.NewFastIntSet()
@@ -728,7 +730,8 @@ func extractEquivalenceCols(Conditions []expression.Expression, p LogicalPlan, f
 
 func (p *LogicalSelection) ExtractFD() *fd.FDSet {
 	// basically extract the children's fdSet.
-	fds := p.baseLogicalPlan.ExtractFD()
+	fds := &fd.FDSet{}
+	fds.CopyFrom(p.baseLogicalPlan.ExtractFD())
 	// collect the output columns' unique ID.
 	outputColsUniqueIDs := fd.NewFastIntSet()
 	notnullColsUniqueIDs := fd.NewFastIntSet()

--- a/planner/core/stringer.go
+++ b/planner/core/stringer.go
@@ -67,6 +67,8 @@ func fdToString(in LogicalPlan, strs []string, idxs []int) ([]string, []int) {
 		}
 	case *DataSource:
 		strs = append(strs, "{"+x.fdSet.String()+"}")
+	case *LogicalSelection:
+		strs = append(strs, "{"+x.fdSet.String()+"}")
 	default:
 	}
 	return strs, idxs

--- a/planner/functional_dependency/extract_fd_test.go
+++ b/planner/functional_dependency/extract_fd_test.go
@@ -24,7 +24,6 @@ func testGetIS(ass *assert.Assertions, ctx sessionctx.Context) infoschema.InfoSc
 }
 
 func TestFDSet_ExtractFD(t *testing.T) {
-	t.Parallel()
 	ass := assert.New(t)
 
 	store, clean := testkit.CreateMockStore(t)
@@ -76,118 +75,118 @@ func TestFDSet_ExtractFD(t *testing.T) {
 		{
 			sql: "select b+1, sum(a) from t1 group by(b)",
 			// since b is projected out, b --> b+1 and b ~~> sum(a) is eliminated.
-			best: "DataScan(t1)->Aggr(sum(test.t1.a),firstrow(test.t1.b))->Projection",
-			fd:   "{(1)-->(2,3), (2,3)~~>(1)} >>> {(2)~~>(4)} >>> {(2)~~>(4), (2)-->(5)}",
+			best: "DataScan(t1)->Aggr(sum(test.t1.a),firstrow(test.t1.a),firstrow(test.t1.b),firstrow(test.t1.c))->Projection",
+			fd:   "{(1)-->(2,3), (2,3)~~>(1)} >>> {(1)-->(2,3), (2,3)~~>(1), (2)~~>(1,3,4)} >>> {(2)-->(5)}",
 		},
 		{
 			sql:  "select b+1, b, sum(a) from t1 group by(b)",
-			best: "DataScan(t1)->Aggr(sum(test.t1.a),firstrow(test.t1.b))->Projection",
-			fd:   "{(1)-->(2,3), (2,3)~~>(1)} >>> {(2)~~>(4)} >>> {(2)~~>(4), (2)-->(5)}",
+			best: "DataScan(t1)->Aggr(sum(test.t1.a),firstrow(test.t1.a),firstrow(test.t1.b),firstrow(test.t1.c))->Projection",
+			fd:   "{(1)-->(2,3), (2,3)~~>(1)} >>> {(1)-->(2,3), (2,3)~~>(1), (2)~~>(1,3,4)} >>> {(2)-->(5)}",
 		},
 		// test for table x1 and x2
 		{
 			sql:  "select a from x1 group by a,b,c",
-			best: "DataScan(x1)->Projection",
-			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {}",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {}",
 		},
 		{
 			sql:  "select b from x1 group by b",
-			best: "DataScan(x1)->Aggr(firstrow(test.x1.b))->Projection",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
 			// b --> b is natural existed, so it won't exist in fd.
-			fd: "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {} >>> {}",
+			fd: "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3), (2)~~>(1,3,4)} >>> {}",
 		},
 		{
 			sql:  "select b as e from x1 group by b",
-			best: "DataScan(x1)->Aggr(firstrow(test.x1.b))->Projection",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
 			// b --> b is naturally existed, so it won't exist in fd.
-			fd: "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {} >>> {}",
+			fd: "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3), (2)~~>(1,3,4)} >>> {}",
 		},
 		{
 			sql:  "select b+c from x1 group by b+c",
-			best: "DataScan(x1)->Aggr(firstrow(test.x1.b),firstrow(test.x1.c))->Projection",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
 			// avoid allocating unique ID 7 from fd temporarily, and substituted by unique ID 5
 			// attention:
 			// b+c is an expr assigned with new plan ID when building upper-layer projection.
 			// when extracting FD after build phase is done, we should be able to recognize a+b in lower-layer group by item with the same unique ID.
 			// that's why we introduce session variable MapHashCode2UniqueID4ExtendedCol in.
-			fd: "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(2,3)-->(5), (5)~~>(2,3)} >>> {(2,3)-->(5), (5)~~>(2,3)}",
+			fd: "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3), (2,3)-->(5), (5)~~>(1-4)} >>> {(2,3)-->(5), (5)~~>(2,3)}",
 		},
 		{
 			sql:  "select b+c, min(a) from x1 group by b+c, b-c",
-			best: "DataScan(x1)->Aggr(min(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c))->Projection",
-			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(2,3)-->(6,8), (6,8)~~>(2,3,5)} >>> {(2,3)-->(6)}",
+			best: "DataScan(x1)->Aggr(min(test.x1.a),firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3), (2,3)-->(6,7), (6,7)~~>(1-5)} >>> {(2,3)-->(6)}",
 		},
 		{
 			sql:  "select b+c, min(a) from x1 group by b, c",
-			best: "DataScan(x1)->Aggr(min(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c))->Projection",
-			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(2,3)~~>(5)} >>> {(2,3)~~>(5), (2,3)-->(6)}",
+			best: "DataScan(x1)->Aggr(min(test.x1.a),firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3), (2,3)~~>(1,4,5)} >>> {(2,3)~~>(5), (2,3)-->(6)}",
 		},
 		{
 			sql:  "select b+c from x1 group by b,c",
-			best: "DataScan(x1)->Aggr(firstrow(test.x1.b),firstrow(test.x1.c))->Projection",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
 			// b --> b is naturally existed, so it won't exist in fd.
-			fd: "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {} >>> {(2,3)-->(5)}",
+			fd: "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)-->(1,4), (2,4)-->(1,3)} >>> {(2,3)-->(5)}",
 		},
 		{
 			sql:  "select case b when 1 then c when 2 then d else d end from x1 group by b,c,d",
-			best: "DataScan(x1)->Projection",
-			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(2,3)~~>(4), (2,4)-->(3,5)}",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(2,3)~~>(4), (2,4)-->(3,5)}",
 		},
 		{
 			// scalar sub query will be substituted with constant datum.
 			sql:  "select c > (select b from x1) from x1 group by c",
-			best: "DataScan(x1)->Aggr(firstrow(test.x1.c))->Projection",
-			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {} >>> {(3)-->(15)}",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3), (3)~~>(1,2,4)} >>> {(3)-->(15)}",
 		},
 		{
 			sql:  "select exists (select * from x1) from x1 group by d",
-			best: "DataScan(x1)->Aggr(firstrow(1))->Projection",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
 			// 14 is added in the logicAgg pruning process cause all the columns of agg has been pruned.
-			fd: "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(4)~~>(14)} >>> {()-->(13)}",
+			fd: "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3), (4)~~>(1-3)} >>> {()-->(13)}",
 		},
 		{
 			sql:  "select c is null from x1 group by c",
-			best: "DataScan(x1)->Aggr(firstrow(test.x1.c))->Projection",
-			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {} >>> {(3)-->(5)}",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3), (3)~~>(1,2,4)} >>> {(3)-->(5)}",
 		},
 		{
 			sql:  "select c is true from x1 group by c",
-			best: "DataScan(x1)->Aggr(firstrow(test.x1.c))->Projection",
-			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {} >>> {(3)-->(5)}",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3), (3)~~>(1,2,4)} >>> {(3)-->(5)}",
 		},
 		{
 			sql: "select (c+b)*d from x1 group by c,b,d",
 			// agg elimination.
-			best: "DataScan(x1)->Projection",
-			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(2,3)~~>(4), (2,4)-->(3,5)}",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(2,3)~~>(4), (2,4)-->(3,5)}",
 		},
 		{
 			sql:  "select b in (c,d) from x1 group by b,c,d",
-			best: "DataScan(x1)->Projection",
-			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(2,3)~~>(4), (2,4)-->(3,5)}",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(2,3)~~>(4), (2,4)-->(3,5)}",
 		},
 		{
 			sql:  "select b like '%a' from x1 group by b",
-			best: "DataScan(x1)->Aggr(firstrow(test.x1.b))->Projection",
-			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {} >>> {(2)-->(5)}",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3), (2)~~>(1,3,4)} >>> {(2)-->(5)}",
 		},
 		// test functional dependency on primary key
 		{
 			sql: "select * from x1 group by a",
 			// agg eliminated by primary key.
-			best: "DataScan(x1)->Projection",
-			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)}",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)}",
 		},
 		// test functional dependency on unique key with not null
 		{
 			sql:  "select * from x1 group by b,d",
-			best: "DataScan(x1)->Projection",
-			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)}",
+			best: "DataScan(x1)->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
+			fd:   "{(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)} >>> {(1)-->(2-4), (2,3)~~>(1,4), (2,4)-->(1,3)}",
 		},
 		// test functional dependency derived from keys in where condition
 		{
 			sql:  "select * from x1 where c = d group by b, c",
-			best: "DataScan(x1)->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
+			best: "DataScan(x1)->Sel([eq(test.x1.c, test.x1.d)])->Aggr(firstrow(test.x1.a),firstrow(test.x1.b),firstrow(test.x1.c),firstrow(test.x1.d))->Projection",
 			// c = d derives:
 			// 1: c and d are not null, make lax FD (2,3)~~>(1,4) to be strict one.
 			// 2: c and d are equivalent.
@@ -210,11 +209,10 @@ func TestFDSet_ExtractFD(t *testing.T) {
 		// extract FD to every OP
 		p, err := builder.Build(ctx, stmt)
 		ass.Nil(err)
-		p, err = plannercore.LogicalOptimizeTest(ctx, builder.GetOptFlag(), p.(plannercore.LogicalPlan))
-		ass.Nil(err)
 		ass.Equal(tt.best, plannercore.ToString(p), comment)
 		// extract FD to every OP
 		p.(plannercore.LogicalPlan).ExtractFD()
+		comment = comment + fmt.Sprintf(" plan: %v", plannercore.ToString(p))
 		ass.Equal(tt.fd, plannercore.FDToString(p.(plannercore.LogicalPlan)), comment)
 	}
 }

--- a/planner/functional_dependency/fd_graph.go
+++ b/planner/functional_dependency/fd_graph.go
@@ -579,6 +579,16 @@ func (s *FDSet) MaxOneRow(cols FastIntSet) {
 	}
 }
 
+func (s *FDSet) CopyFrom(srcSet *FDSet) {
+	s.fdEdges = make([]*fdEdge, len(srcSet.fdEdges))
+	copy(s.fdEdges, srcSet.fdEdges)
+	s.NotNullCols.CopyFrom(srcSet.NotNullCols)
+	s.HashCodeToUniqueID = make(map[string]int, len(srcSet.HashCodeToUniqueID))
+	for k, v := range srcSet.HashCodeToUniqueID {
+		s.HashCodeToUniqueID[k] = v
+	}
+}
+
 // ProjectCols projects FDSet to the target columns
 // Formula:
 // Strict decomposition FD4A: If X −→ Y Z then X −→ Y and X −→ Z.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

To support `only_full_group_by` checking and to test the basic usage. We just test the FD result after the plan building phase.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

