### PR TITLE
Fix 22301 and 33056

### DIFF
--- a/parser/ast/dml.go
+++ b/parser/ast/dml.go
@@ -690,7 +690,9 @@ type SelectField struct {
 	// Auxiliary stands for if this field is auxiliary.
 	// When we add a Field into SelectField list which is used for having/orderby clause but the field is not in select clause,
 	// we should set its Auxiliary to true. Then the TrimExec will trim the field.
-	Auxiliary bool
+	Auxiliary             bool
+	AuxiliaryColInAgg     bool
+	AuxiliaryColInOrderBy bool
 }
 
 // Restore implements Node interface.

--- a/planner/funcdep/only_full_group_by_test.go
+++ b/planner/funcdep/only_full_group_by_test.go
@@ -207,4 +207,12 @@ func TestOnlyFullGroupByOldCases(t *testing.T) {
 	err = tk.ExecToErr("SELECT * FROM t2 AS _tmp_1 JOIN (SELECT max(_tmp_3.f2) AS _tmp_4,min(_tmp_3.i2) AS _tmp_5 FROM t2 AS _tmp_3 WHERE _tmp_3.f2>=_tmp_3.c2 GROUP BY _tmp_3.c2 ORDER BY _tmp_3.i2) AS _tmp_2 WHERE _tmp_2._tmp_5=100;")
 	require.NotNil(t, err)
 	require.Equal(t, err.Error(), "[planner:1055]Expression #3 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'test._tmp_3.i2' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by")
+
+	// test issue #22301
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1 (a int);")
+	tk.MustExec("create table t2 (a int, b int);")
+	tk.MustQuery("select t1.a from t1 join t2 on t2.a=t1.a group by t2.a having min(t2.b) > 0;")
+	tk.MustQuery("select t2.a, count(t2.b) from t1 join t2 using (a) where t1.a = 1;")
+	tk.MustQuery("select count(t2.b) from t1 join t2 using (a) order by t2.a;")
 }

--- a/planner/funcdep/only_full_group_by_test.go
+++ b/planner/funcdep/only_full_group_by_test.go
@@ -208,7 +208,7 @@ func TestOnlyFullGroupByOldCases(t *testing.T) {
 	require.NotNil(t, err)
 	require.Equal(t, err.Error(), "[planner:1055]Expression #3 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'test._tmp_3.i2' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by")
 
-	// test issue #22301
+	// test issue #22301 and #33056
 	tk.MustExec("drop table if exists t1, t2")
 	tk.MustExec("create table t1 (a int);")
 	tk.MustExec("create table t2 (a int, b int);")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #22301 and #33056

### What is changed and how it works?
```
drop table if exists t1, t2;
create table t1 (a int);
create table t2 (a int, b int);
select t1.a from t1 join t2 on t2.a=t1.a group by t2.a having min(t2.b) > 0;
```
22301: having and order-by clause will append additional select fields into original select. there are some difference:
for having: the direct expr/col should be limited with only-full-group-by
for order by: the direct expr/col should be limited with only-full-group-by when group-cols are NOT empty.
for both: the base col extracted from these clause don't have to be checked with only-full-group-by

```
create table t1 (a int);
create table t2 (a int, b int);
select t2.a, count(t2.b) from t1 join t2 using (a) where t1.a = 1;
```
33056:  inner join with using will hide some col, which cause the agg can't find it with there is a selection above the join; besides, FD in selection should also take into consideration of this kind of full schema, otherwise, will wrongly project out some column'FD, for example here, t2.a

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
