### PR TITLE
reslove the correlated agg func's correlated col when it in the sub-query

### DIFF
--- a/planner/funcdep/only_full_group_by_test.go
+++ b/planner/funcdep/only_full_group_by_test.go
@@ -215,4 +215,12 @@ func TestOnlyFullGroupByOldCases(t *testing.T) {
 	tk.MustQuery("select t1.a from t1 join t2 on t2.a=t1.a group by t2.a having min(t2.b) > 0;")
 	tk.MustQuery("select t2.a, count(t2.b) from t1 join t2 using (a) where t1.a = 1;")
 	tk.MustQuery("select count(t2.b) from t1 join t2 using (a) order by t2.a;")
+
+	// test issue #30024
+	tk.MustExec("drop table if exists t1,t2;")
+	tk.MustExec("CREATE TABLE t1 (a INT, b INT, c INT DEFAULT 0);")
+	tk.MustExec("INSERT INTO t1 (a, b) VALUES (3,3), (2,2), (3,3), (2,2), (3,3), (4,4);")
+	tk.MustExec("CREATE TABLE t2 (a INT, b INT, c INT DEFAULT 0);")
+	tk.MustExec("INSERT INTO t2 (a, b) VALUES (3,3), (2,2), (3,3), (2,2), (3,3), (4,4);")
+	tk.MustQuery("SELECT t1.a FROM t1 GROUP BY t1.a HAVING t1.a IN (SELECT t2.a FROM t2 ORDER BY SUM(t1.b));")
 }


### PR DESCRIPTION

Signed-off-by: ailinkid <314806019@qq.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #30024: reslove the correlated agg func's correlated col when it in the sub-query

Reason: kind of name resolver problem, the agg inside sub-query is actually correlated with the outside group, so does the col name inside the agg func. this two expr should be built/kept in the outer schema, otherwise, when we are building having clause, the sub-query couldn't find the reference anywhere.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
