### PR TITLE
planner: fix that normal index cannot build fd

### DIFF
--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -4469,13 +4469,8 @@ func (ds *DataSource) ExtractFD() *fd.FDSet {
 					// 1: normal value should be unique
 					// 2: null value can be multiple
 					// for this kind of lax to be strict, we need to make the determinant not-null.
-					fds.AddLaxFunctionalDependency(keyCols, allCols, true)
+					fds.AddLaxFunctionalDependency(keyCols, allCols)
 				}
-			} else {
-				// 1: normal value can be multiple
-				// 2: null value can be multiple
-				// for this kind of lax to be strict, we need to make both the determinant and dependency not-null.
-				fds.AddLaxFunctionalDependency(keyCols, allCols, false)
 			}
 		}
 		// handle the datasource conditions (maybe pushed down from upper layer OP)

--- a/planner/funcdep/fd_graph_ported_test.go
+++ b/planner/funcdep/fd_graph_ported_test.go
@@ -28,7 +28,7 @@ func makeAbcdeFD(ass *assert.Assertions) *FDSet {
 	allCols := NewFastIntSet(1, 2, 3, 4, 5)
 	abcde := &FDSet{}
 	abcde.AddStrictFunctionalDependency(NewFastIntSet(1), allCols)
-	abcde.AddLaxFunctionalDependency(NewFastIntSet(2, 3), allCols, false)
+	abcde.AddLaxFunctionalDependency(NewFastIntSet(2, 3), allCols)
 
 	testColsAreStrictKey(ass, abcde, NewFastIntSet(1), allCols, true)
 	testColsAreStrictKey(ass, abcde, NewFastIntSet(2, 3), allCols, false)
@@ -130,8 +130,8 @@ func TestFuncDeps_ProjectCols(t *testing.T) {
 	foo := &FDSet{}
 	all := NewFastIntSet(1, 2, 3, 4)
 	foo.AddStrictFunctionalDependency(NewFastIntSet(1), all)
-	foo.AddLaxFunctionalDependency(NewFastIntSet(2, 3), all, false)
-	foo.AddLaxFunctionalDependency(NewFastIntSet(4), all, false)
+	foo.AddLaxFunctionalDependency(NewFastIntSet(2, 3), all)
+	foo.AddLaxFunctionalDependency(NewFastIntSet(4), all)
 	ass.Equal("(1)-->(2-4), (2,3)~~>(1,4), (4)~~>(1-3)", foo.String())
 	foo.MakeNotNull(NewFastIntSet(1, 4))
 	//  nothing change.
@@ -280,8 +280,8 @@ func TestFuncDeps_ProjectCols(t *testing.T) {
 	// projected away.
 	abcde = &FDSet{}
 	abcde.AddStrictFunctionalDependency(NewFastIntSet(1), NewFastIntSet(1, 2, 3, 4, 5))
-	abcde.AddLaxFunctionalDependency(NewFastIntSet(2), NewFastIntSet(1, 2, 3, 4, 5), false)
-	abcde.AddLaxFunctionalDependency(NewFastIntSet(3, 4), NewFastIntSet(1, 2, 3, 4, 5), false)
+	abcde.AddLaxFunctionalDependency(NewFastIntSet(2), NewFastIntSet(1, 2, 3, 4, 5))
+	abcde.AddLaxFunctionalDependency(NewFastIntSet(3, 4), NewFastIntSet(1, 2, 3, 4, 5))
 	ass.Equal("(1)-->(2-5), (2)~~>(1,3-5), (3,4)~~>(1,2,5)", abcde.String())
 	abcde.MakeNotNull(NewFastIntSet(1))
 	abcde.ProjectCols(NewFastIntSet(2, 3, 4, 5))

--- a/planner/funcdep/fd_graph_test.go
+++ b/planner/funcdep/fd_graph_test.go
@@ -236,7 +236,7 @@ func TestFDSet_AddConstant(t *testing.T) {
 	require.Equal(t, "(4)", fd.fdEdges[1].from.String()) // determinant 3 reduced as constant, leaving FD {d} --> {f,g}.
 	require.Equal(t, "(5,6)", fd.fdEdges[1].to.String())
 
-	fd.AddLaxFunctionalDependency(NewFastIntSet(7), NewFastIntSet(5, 6), false) // {g} ~~> {e,f}
+	fd.AddLaxFunctionalDependency(NewFastIntSet(7), NewFastIntSet(5, 6)) // {g} ~~> {e,f}
 	require.Equal(t, len(fd.fdEdges), 3)
 	require.False(t, fd.fdEdges[2].strict)
 	require.False(t, fd.fdEdges[2].equiv)
@@ -254,25 +254,25 @@ func TestFDSet_AddConstant(t *testing.T) {
 
 func TestFDSet_LaxImplies(t *testing.T) {
 	fd := FDSet{}
-	fd.AddLaxFunctionalDependency(NewFastIntSet(1), NewFastIntSet(2, 3), false)
-	fd.AddLaxFunctionalDependency(NewFastIntSet(1), NewFastIntSet(2), false)
+	fd.AddLaxFunctionalDependency(NewFastIntSet(1), NewFastIntSet(2, 3))
+	fd.AddLaxFunctionalDependency(NewFastIntSet(1), NewFastIntSet(2))
 	// lax FD won't imply each other once they have the different to side.
 	require.Equal(t, "(1)~~>(2,3), (1)~~>(2)", fd.String())
 
 	fd = FDSet{}
-	fd.AddLaxFunctionalDependency(NewFastIntSet(1), NewFastIntSet(2), false)
-	fd.AddLaxFunctionalDependency(NewFastIntSet(1), NewFastIntSet(2, 3), false)
+	fd.AddLaxFunctionalDependency(NewFastIntSet(1), NewFastIntSet(2))
+	fd.AddLaxFunctionalDependency(NewFastIntSet(1), NewFastIntSet(2, 3))
 	require.Equal(t, "(1)~~>(2), (1)~~>(2,3)", fd.String())
 
 	fd = FDSet{}
-	fd.AddLaxFunctionalDependency(NewFastIntSet(1), NewFastIntSet(3), false)
-	fd.AddLaxFunctionalDependency(NewFastIntSet(1, 2), NewFastIntSet(3), false)
+	fd.AddLaxFunctionalDependency(NewFastIntSet(1), NewFastIntSet(3))
+	fd.AddLaxFunctionalDependency(NewFastIntSet(1, 2), NewFastIntSet(3))
 	// lax FD can imply each other once they have the same to side. {1,2} ~~> {3} implies {1} ~~> {3}
 	require.Equal(t, "(1)~~>(3)", fd.String())
 
 	fd = FDSet{}
-	fd.AddLaxFunctionalDependency(NewFastIntSet(1), NewFastIntSet(3, 4), false)
-	fd.AddLaxFunctionalDependency(NewFastIntSet(1, 2), NewFastIntSet(3), false)
+	fd.AddLaxFunctionalDependency(NewFastIntSet(1), NewFastIntSet(3, 4))
+	fd.AddLaxFunctionalDependency(NewFastIntSet(1, 2), NewFastIntSet(3))
 	// lax FD won't imply each other once they have the different to side. {1,2} ~~> {3} implies {1} ~~> {3}
 	require.Equal(t, "(1)~~>(3,4), (1,2)~~>(3)", fd.String())
 }

--- a/planner/funcdep/only_full_group_by_test.go
+++ b/planner/funcdep/only_full_group_by_test.go
@@ -223,4 +223,11 @@ func TestOnlyFullGroupByOldCases(t *testing.T) {
 	tk.MustExec("CREATE TABLE t2 (a INT, b INT, c INT DEFAULT 0);")
 	tk.MustExec("INSERT INTO t2 (a, b) VALUES (3,3), (2,2), (3,3), (2,2), (3,3), (4,4);")
 	tk.MustQuery("SELECT t1.a FROM t1 GROUP BY t1.a HAVING t1.a IN (SELECT t2.a FROM t2 ORDER BY SUM(t1.b));")
+
+	// a normal case
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1(a int not null, b int not null, index(a))")
+	err = tk.ExecToErr("select b from t1 group by a")
+	require.NotNil(t, err)
+	require.Equal(t, err.Error(), "[planner:1055]Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'test.t1.b' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by")
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?

This one solves the case that we cannot use the normal index to build fd.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - [x] Unit test
