### PR TITLE
refactor order-by fd check

### DIFF
--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -1942,7 +1942,7 @@ func (b *PlanBuilder) buildSortCheck(ctx context.Context, p LogicalPlan, sel *as
 			if sel.Distinct {
 				// order-by with distinct case
 				// Rule #1: order by item should be in the select filed list
-				// Rule #2: the base col that order by item dependent on should be in the select field list
+				// Rule #2: the base col that order by item is dependent on should be in the select field list
 				for offset, odrItem := range orderByItemExprs {
 					item := fd.NewFastIntSet()
 					switch x := odrItem.Expr.(type) {

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -15,10 +15,6 @@
 package core
 
 import (
-	"fmt"
-	"math"
-	"strings"
-
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/aggregation"
 	"github.com/pingcap/tidb/infoschema"
@@ -36,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/ranger"
 	"go.uber.org/zap"
+	"math"
 )
 
 var (
@@ -368,9 +365,6 @@ func (p *LogicalJoin) extractFDForOuterJoin(filtersFromApply []expression.Expres
 	}
 	fds := outerFD
 
-	if strings.HasPrefix(p.ctx.GetSessionVars().StmtCtx.OriginalSQL, "select c1.a, count(*) from customer2 c3 left join (customer1 c1 left join customer2 c2 on c1.a=c2.b) on c3.b=c1.a where c2.pk in (7,9) group by c2.b") {
-		fmt.Println(1)
-	}
 	fds.MakeOuterJoin(innerFD, filterFD, outerCols, innerCols, &opt, innerAcrossBlock)
 	p.fdSet = fds
 	return fds

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -15,7 +15,9 @@
 package core
 
 import (
+	"fmt"
 	"math"
+	"strings"
 
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/aggregation"
@@ -365,6 +367,10 @@ func (p *LogicalJoin) extractFDForOuterJoin(filtersFromApply []expression.Expres
 		outerFD.GroupByCols.Clear()
 	}
 	fds := outerFD
+
+	if strings.HasPrefix(p.ctx.GetSessionVars().StmtCtx.OriginalSQL, "select c1.a, count(*) from customer2 c3 left join (customer1 c1 left join customer2 c2 on c1.a=c2.b) on c3.b=c1.a where c2.pk in (7,9) group by c2.b") {
+		fmt.Println(1)
+	}
 	fds.MakeOuterJoin(innerFD, filterFD, outerCols, innerCols, &opt, innerAcrossBlock)
 	p.fdSet = fds
 	return fds
@@ -1007,19 +1013,6 @@ func (p *LogicalSelection) ExtractFD() *fd.FDSet {
 
 	// extract equivalence cols.
 	equivUniqueIDs := extractEquivalenceCols(p.Conditions, p.SCtx(), fds)
-
-	// after left join, according to rule 3.3.3, it may create a lax FD from inner equivalence
-	// cols pointing to outer equivalence cols.  eg: t left join t1 on t.a = t1.b, leading a
-	// lax FD from t1.b ~> t.a, this lax attribute is coming from supplied null value to all
-	// left rows, once there is a null-refusing predicate on the inner side on upper layer, this
-	// can be equivalence again. (the outer rows left are all coming from equal matching)
-	//
-	// why not just makeNotNull of them, because even a non-equiv-related inner col can also
-	// refuse supplied null values.
-	if fds.Rule333Equiv.InnerCols.Len() != 0 && notnullColsUniqueIDs.Intersects(fds.Rule333Equiv.InnerCols) {
-		// restore/re-strength FDs from rule 333
-		fds.MakeRestoreRule333()
-	}
 
 	// apply operator's characteristic's FD setting.
 	fds.MakeNotNull(notnullColsUniqueIDs)

--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -377,7 +377,8 @@ type baseLogicalPlan struct {
 	// including eliminating unnecessary DISTINCT operators, simplifying ORDER BY columns,
 	// removing Max1Row operators, and mapping semi-joins to inner-joins.
 	// for now, it's hard to maintain in individual operator, build it from bottom up when using.
-	fdSet *fd.FDSet
+	fdSet     *fd.FDSet
+	FDChecked bool
 }
 
 // ExtractFD return the children[0]'s fdSet if there are no adding/removing fd in this logic plan.

--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -386,8 +386,13 @@ func (p *baseLogicalPlan) ExtractFD() *fd.FDSet {
 		return p.fdSet
 	}
 	fds := &fd.FDSet{HashCodeToUniqueID: make(map[string]int)}
+	// isolation between different logical selection blocks.
+	acrossBlock := false
 	for _, ch := range p.children {
-		fds.AddFrom(ch.ExtractFD())
+		if p.SelectBlockOffset() != ch.SelectBlockOffset() {
+			acrossBlock = true
+		}
+		fds.AddFrom(ch.ExtractFD(), acrossBlock)
 	}
 	return fds
 }

--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -387,7 +387,7 @@ func (p *baseLogicalPlan) ExtractFD() *fd.FDSet {
 		return p.fdSet
 	}
 	fds := &fd.FDSet{HashCodeToUniqueID: make(map[string]int)}
-	// isolation between different logical selection blocks.
+	// isolation between different logical query blocks.
 	acrossBlock := false
 	for _, ch := range p.children {
 		if p.SelectBlockOffset() != ch.SelectBlockOffset() {

--- a/planner/funcdep/doc.go
+++ b/planner/funcdep/doc.go
@@ -10,3 +10,154 @@ package funcdep
 //   https://cs.uwaterloo.ca/research/tr/2000/11/CS-2000-11.thesis.pdf
 
 // TODO: Add the RFC design.
+
+// NOTE 1.
+// when handling Lax FD, we don't care the null value in the dependency, which means
+// as long as null-attribute coverage of the determinant can make a Lax FD as strict one.
+
+// The definition of "lax" used in the paper differs from the definition used by this
+// library. For a lax dependency A~~>B, the paper allows this set of rows:
+//
+//	a  b
+//	-------
+//	1  1
+//	1  NULL
+//
+//	This alternate definition is briefly covered in section 2.5.3.2 of the paper (see definition
+//	2.19). The reason for this change is to allow a lax dependency to be upgraded to a strict
+//	dependency more readily, needing only the determinant columns to be not-null rather than
+//  both determinant and dependant columns.
+//
+// This is on the condition that, for definite values of determinant of a Lax FD, it won't
+// have two same definite dependant value. That's true, because there is no way can derive
+// to this kind of FD.
+//
+// Even in our implementation of outer join, the only way to produce duplicate definite
+// determinant is the join predicate. But for now, we only maintain the equivalence and
+// some strict FD of it.
+//
+//   t(a,b) left join t1(c,d,e) on t.a = t1.c and b=1
+//  a  b  |  c     d     e
+//  ------+----------------
+//  1  1  |  1    NULL   1
+//  1  2  | NULL  NULL  NULL
+//  2  1  | NULL  NULL  NULL
+//
+// Actually it's possible, the lax FD {a} -> {c} can be derived but not that useful. we only
+// maintain the {c} ~> {a} for existence after outer join. Besides, there two Cond-FD should
+// be preserved waiting for be visible again once with the null-reject on the condition of
+// null constraint columns. (see below)
+//
+// NOTE 2.
+// When handle outer join, it won't produce lax FD with duplicate definite determinant values and
+// different dependency values.
+//
+// In implementation，we come across some lax FD dependent on null-reject of some other cols. For
+// example.
+//   t(a,b) left join t1(c,d,e) on t.a = t1.c and b=1
+//  a  b  |  c     d     e
+//  ------+----------------
+//  1  1  |  1    NULL   1
+//  1  2  | NULL  NULL  NULL
+//  2  1  | NULL  NULL  NULL
+//
+// here constant FD {} -> {b} won't be existed after the outer join is done. Notice null-constraint
+// {c,d,e} -| {c,d,e}, this FD should be preserved and will be visible again when some null-reject
+// predicate take effect on the null-constraint cols.
+//
+// It's same for strict equivalence {t.a} = {t1.c}. Notice there are no lax equivalence here, because
+// left side couldn't be guaranteed to be definite or null. like a=2 here. Let's collect all of this
+// on-condition FD down, correspondent with a null-constraints column set, name it as Cond-FD.
+//
+// lax equivalencies are theoretically possible, but it won't be constructed from an outer join unless
+// t already has a constant FD in column `a` here before outer join take a run. So the lax equivalence
+// has some pre-conditions as you see, and it couldn't cover the case shown above. Let us do it like a
+// Cond-FD does.
+//
+// The FD constructed from the join predicate should be considered as Cond-FD. Here like equivalence of
+// {a} == {c} and constant FD {b} = 1 (if the join condition is e=1, it's here too). We can say that for
+// every matched row, this FDs is valid, while for the other rows, the inner side are supplied of null
+// rows. So this FDs are stored as ncEdges with nc condition of all inner table cols.
+//
+// We introduced invisible FD with null-constraint column to solve the problem above named as Cond-FD.
+// For multi embedded left join, we take the following case as an example.
+//    a,b         c,d,e
+// 	-----------+-----------
+//   1    2    |    1  1  1
+// 	 2    2    |
+//  -----------+-----------
+//
+//  left join on (a=c) res:
+//   a   b    c     e     e
+//  -------------------------
+//   1   2    1     1     1
+//   2   2 +- null null  null -+
+//         |                   |
+//         +-------------------+
+//                              \
+//                               \
+//  the Cond-FD are < a=c with {c,d,e} > the latter is as null constraint cols
+//
+//    e,f
+//  -----------------------
+//   1   2
+//   2   2
+//   3   3
+//  -----------------------
+//
+//  left join on (e=a) res:
+//   e   f    a     b      c    d    e
+//  -----------------------------------
+//   1   2    1     2      1    1    1
+//   2   2    2     2  +- null null null --+---------------> Cond-FD are <a=c with {c,d,e}> still exists.
+//   3   3 +-null null |  null null null   |---+
+//         |           +-------------------+   |
+//         +-----------------------------------+-----------> New Cond-FD are <e=a with {a,b,c,d,e}> occurs.
+//
+//
+// the old Cond-FD with null constraint columns set {c,d,e} is preserved cause new append cols are all null too.
+// the new Cond-FD with null constraint columns set {a,b,c,d,e} are also meaningful, even if the null-reject column
+// is one of {c,d,e} which may reduce one of the matched row out of the result, the equivalence {a}={e} still exist.
+//
+// Provide that the result of the first left join is like:
+//  left join on (a=c) res:
+//   a     b    c     e     e
+//  ---------------------------
+//   1     2    1     1     1
+//   null  2  null  null  null
+//
+//  THEN: left join on (e=a) res:
+//   e   f    a     b     c    d    e
+//  ---------------------------------
+//   1   2    1     2     1    1    1
+//   2   2    null null null null null
+//   3   3    3     3   null null null
+//
+//  Even like that, the case of old Cond-FD and new Cond-FD are existed too. Seems the null-constraint column set of
+//  old Cond-FD {c,d,e} can be expanded as {a,b,c,d,e} visually, but we couldn't derive the inference of the join predicate
+//  (e=a). The null-reject of column `a` couldn't bring the visibility to the old Cond-FD theoretically, it just happened
+//  to refuse that row with a null value in column a.
+//
+// Think about adding one more row in first left join result.
+//
+//  left join on (a=c) res:
+//   a     b    c     e     e
+//  ---------------------------
+//   1     2    1     1     1
+//   null  2  null  null  null
+//   3     3  null  null  null
+//
+//  THEN: left join on (e=a) res:
+//   e   f    a     b     c    d    e
+//  ---------------------------------
+//   1   2    1     2     1    1    1
+//   2   2    null null null null null
+//   3   3    3     3   null null null
+//
+//  Conclusion:
+//  As you see that's right we couldn't derive the inference of the join predicate (e=a) to expand old Cond-FD's nc
+//  {c,d,e} as {a,b,c,d,e}. So the rule for Cond-FD is quite simple, just keep the old ncEdge from right, appending
+//  the new ncEdges in current left join.
+//
+//  If the first left join result is in the outer side of the second left join, just keep the ncEdge from left as well,
+//  appending the new ncEdges in current left join.

--- a/planner/funcdep/extract_fd_test.go
+++ b/planner/funcdep/extract_fd_test.go
@@ -349,9 +349,6 @@ func TestFDSet_MakeOuterJoin(t *testing.T) {
 	ctx := context.TODO()
 	is := testGetIS(ass, tk.Session())
 	for i, tt := range tests {
-		if i == 0 {
-			fmt.Println(1)
-		}
 		comment := fmt.Sprintf("case:%v sql:%s", i, tt.sql)
 		stmt, err := par.ParseOneStmt(tt.sql, "", "")
 		ass.Nil(err, comment)

--- a/planner/funcdep/fd_graph.go
+++ b/planner/funcdep/fd_graph.go
@@ -29,14 +29,48 @@ type fdEdge struct {
 	// The value of the strict and eq bool forms the four kind of edges:
 	// functional dependency, lax functional dependency, strict equivalence constraint, lax equivalence constraint.
 	// And if there's a functional dependency `const` -> `column` exists. We would let the from side be empty.
+	// Adjustment: when strict is true and equiv is false, it means the edge is a Lax equivalence; when both true,
+	// it means the original Strict Equivalence.
+	// LAX EQ: (must have the exact same number of columns in each side if a lax EQ)
+	// {A} ~= {C} should be strengthened as {A} == {C} only with AC as definite.
+	// {A} ~= {C} & {C} ~= {D} unless C is definite, we won't get {A} ~= {D}. eg: {1} ~= {null} ~= {2}
+	// {AB} ~= {CD} won't derive to {A} ~= {C}, the opposite side is either, eg: {1,null} ~= {2,null} & {1,2} !(~=) {1,3}
 	strict bool
 	equiv  bool
+
+	// FD with non-nil conditionNC is hidden in FDSet, it will be visible again when at least one null-reject column in conditionNC.
+	// conditionNC should be satisfied before some FD make vision again, it's quite like lax FD to be strengthened as strict
+	// one. But the constraints should take effect on specified columns from conditionNC rather than just determinant columns.
+	conditionNC *FastIntSet
+}
+
+// ncEdge is quite simple for remarking the null value relationship between cols, storing it as fdEdge will add complexity of traverse of a closure.
+type ncEdge struct {
+	// null constraints = determinants -> dependencies
+	// determinants = from
+	// dependencies = to
+	// when the `from` side is null, the `to` side must be null as well.
+	//  -------------------------------
+	//   e   f   a     b   c    d    e
+	//   1   2   1     2   1    1    1
+	//   2   2  null   2  null null null
+	//   3   3  null null null null null
+	// {b} -| {a,c,d,e}
+	// {a,c,d,e} -| {a,c,d,e}
+	from FastIntSet
+	to   FastIntSet
 }
 
 // FDSet is the main portal of functional dependency, it stores the relationship between (extended table / physical table)'s
 // columns. For more theory about this design, ref the head comments in the funcdep/doc.go.
 type FDSet struct {
 	fdEdges []*fdEdge
+	// after left join, according to rule 3.3.3, it may create a lax FD from inner equivalence
+	// cols pointing to outer equivalence cols.  eg: t left join t1 on t.a = t1.b, leading a
+	// lax FD from t1.b ~> t.a, this lax attribute is coming from supplied null value to all
+	// left rows, once there is a null-refusing predicate on the inner side on upper layer, this
+	// can be equivalence again. (the outer rows left are all coming from equal matching)
+	ncEdges []*fdEdge
 	// NotNullCols is used to record the columns with not-null attributes applied.
 	// eg: {1} ~~> {2,3}, when {2,3} not null is applied, it actually does nothing.
 	// but we should record {2,3} as not-null down for the convenience of transferring
@@ -49,19 +83,7 @@ type FDSet struct {
 	// GroupByCols is used to record columns / expressions that under the group by phrase.
 	GroupByCols FastIntSet
 	HasAggBuilt bool
-	// after left join, according to rule 3.3.3, it may create a lax FD from inner equivalence
-	// cols pointing to outer equivalence cols.  eg: t left join t1 on t.a = t1.b, leading a
-	// lax FD from t1.b ~> t.a, this lax attribute is coming from supplied null value to all
-	// left rows, once there is a null-refusing predicate on the inner side on upper layer, this
-	// can be equivalence again. (the outer rows left are all coming from equal matching)
-	//
-	// why not just makeNotNull of them, because even a non-equiv-related inner col can also
-	// refuse supplied null values.
 	// todo: when multi join and across select block, this may need to be maintained more precisely.
-	Rule333Equiv struct {
-		Edges     []*fdEdge
-		InnerCols FastIntSet
-	}
 }
 
 // ClosureOfStrict is exported for outer usage.
@@ -215,6 +237,19 @@ func (s *FDSet) AddLaxFunctionalDependency(from, to FastIntSet) {
 	s.addFunctionalDependency(from, to, false, false)
 }
 
+func (s *FDSet) AddNCFunctionalDependency(from, to, nc FastIntSet, strict, equiv bool) {
+	// Since nc edge is invisible by now, just collecting them together simply, once the
+	// null-reject on nc cols is satisfied, let's pick them out and insert into the fdEdge
+	// normally.
+	s.ncEdges = append(s.ncEdges, &fdEdge{
+		from:        from,
+		to:          to,
+		strict:      strict,
+		equiv:       equiv,
+		conditionNC: &nc,
+	})
+}
+
 // addFunctionalDependency will add strict/lax functional dependency to the fdGraph.
 // eg:
 // CREATE TABLE t (a int key, b int, c int, d int, e int, UNIQUE (b,c))
@@ -287,6 +322,7 @@ func (s *FDSet) addFunctionalDependency(from, to FastIntSet, strict, equiv bool)
 // implies is used to shrink the edge size, keeping the minimum of the functional dependency set size.
 func (e *fdEdge) implies(otherEdge *fdEdge) bool {
 	// The given one's from should be larger than the current one and the current one's to should be larger than the given one.
+	// ***************************** IMPLY IN SAME TYPE*********************************************
 	// STRICT FD:
 	// A --> C is stronger than AB --> C. --- YES
 	// A --> BC is stronger than A --> C. --- YES
@@ -294,6 +330,19 @@ func (e *fdEdge) implies(otherEdge *fdEdge) bool {
 	// LAX FD:
 	// 1: A ~~> C is stronger than AB ~~> C. --- YES
 	// 2: A ~~> BC is stronger than A ~~> C. --- NO
+	//
+	// STRICT EQ:
+	// since {superset} == {superset} won't collapse with each other. --- NO
+	//
+	// LAX EQ:
+	// 1: {A} ~= {C} is stronger than {AB} ~= {CD}. --- NO
+	// 2: {AB} ~= {CD} is stronger than {A} ~= {C}. --- NO
+	//
+	// ***************************** IMPLY IN DIFF TYPE*********************************************
+	// 1: {A} == {B} is stronger than {A} ~= {B}, {A} -> {B}, {A} ~> {B}
+	// 2: {A} ~= {B} is stronger than {A} ~> {B}
+	// 3: {A} -> {B} is stronger than {A} ~> {B}
+	//
 	// The precondition for 2 to be strict FD is much easier to satisfied than 1, only to
 	// need {a,c} is not null. So we couldn't merge this two to be one lax FD.
 	// but for strict/equiv FD implies lax FD, 1 & 2 is implied both reasonably.
@@ -425,6 +474,7 @@ func (s *FDSet) AddConstants(cons FastIntSet) {
 					shouldRemoved = true
 				}
 			}
+			// pre-condition NOTE 1 in doc.go, it won't occur duplicate definite determinant of Lax FD.
 			// for strict or lax FDs, both can reduce the dependencies side columns with constant closure.
 			if fd.removeColumnsToSide(cols) {
 				shouldRemoved = true
@@ -507,6 +557,29 @@ func (s *FDSet) EquivalenceCols() (eqs []*FastIntSet) {
 func (s *FDSet) MakeNotNull(notNullCols FastIntSet) {
 	notNullCols.UnionWith(s.NotNullCols)
 	notNullColsSet := s.closureOfEquivalence(notNullCols)
+	// make nc FD visible.
+	for i := 0; i < len(s.ncEdges); i++ {
+		fd := s.ncEdges[i]
+		if fd.conditionNC.Intersects(notNullColsSet) {
+			// condition satisfied.
+			s.ncEdges = append(s.ncEdges[:i], s.ncEdges[i+1:]...)
+			i--
+			if fd.isConstant() {
+				s.AddConstants(fd.to)
+			} else if fd.equiv {
+				s.AddEquivalence(fd.from, fd.to)
+				newNotNullColsSet := s.closureOfEquivalence(notNullColsSet)
+				if !newNotNullColsSet.Difference(notNullColsSet).IsEmpty() {
+					notNullColsSet = newNotNullColsSet
+					// expand not-null set.
+					i = -1
+				}
+			} else {
+				s.addFunctionalDependency(fd.from, fd.to, fd.strict, fd.equiv)
+			}
+		}
+	}
+	// make origin FD strengthened.
 	for i := 0; i < len(s.fdEdges); i++ {
 		fd := s.fdEdges[i]
 		if fd.strict {
@@ -711,18 +784,15 @@ func (s *FDSet) MakeOuterJoin(innerFDs, filterFDs *FDSet, outerCols, innerCols F
 			s.addFunctionalDependency(edge.from, edge.to, false, edge.equiv)
 		}
 	}
+	for _, edge := range innerFDs.ncEdges {
+		s.ncEdges = append(s.ncEdges, edge)
+	}
 	leftCombinedFDFrom := NewFastIntSet()
 	leftCombinedFDTo := NewFastIntSet()
 	for _, edge := range filterFDs.fdEdges {
 		// Rule #3.2, constant FD are removed from right side of left join.
 		if edge.isConstant() {
-			s.Rule333Equiv.Edges = append(s.Rule333Equiv.Edges, &fdEdge{
-				from:   edge.from,
-				to:     edge.to,
-				strict: edge.strict,
-				equiv:  edge.equiv,
-			})
-			s.Rule333Equiv.InnerCols = innerCols
+			s.AddNCFunctionalDependency(edge.from, edge.to, innerCols, edge.strict, edge.equiv)
 			continue
 		}
 		// Rule #3.3, we only keep the lax FD from right side pointing the left side.
@@ -764,13 +834,7 @@ func (s *FDSet) MakeOuterJoin(innerFDs, filterFDs *FDSet, outerCols, innerCols F
 					s.addFunctionalDependency(NewFastIntSet(i), NewFastIntSet(j), false, false)
 				}
 			}
-			s.Rule333Equiv.Edges = append(s.Rule333Equiv.Edges, &fdEdge{
-				from:   laxFDFrom,
-				to:     laxFDTo,
-				strict: true,
-				equiv:  true,
-			})
-			s.Rule333Equiv.InnerCols = innerCols
+			s.AddNCFunctionalDependency(equivColsLeft, equivColsRight, innerCols, true, true)
 		}
 		// Rule #3.1, filters won't produce any strict/lax FDs.
 	}
@@ -823,18 +887,6 @@ func (s *FDSet) MakeOuterJoin(innerFDs, filterFDs *FDSet, outerCols, innerCols F
 		}
 		s.HasAggBuilt = s.HasAggBuilt || innerFDs.HasAggBuilt
 	}
-}
-
-func (s *FDSet) MakeRestoreRule333() {
-	for _, eg := range s.Rule333Equiv.Edges {
-		if eg.isConstant() {
-			s.AddConstants(eg.to)
-		} else {
-			s.AddEquivalence(eg.from, eg.to)
-		}
-	}
-	s.Rule333Equiv.Edges = nil
-	s.Rule333Equiv.InnerCols.Clear()
 }
 
 type ArgOpts struct {
@@ -900,6 +952,10 @@ func (s *FDSet) AddFrom(fds *FDSet, acrossBlock bool) {
 			s.AddLaxFunctionalDependency(fd.from, fd.to)
 		}
 	}
+	for i := range fds.ncEdges {
+		fd := fds.ncEdges[i]
+		s.ncEdges = append(s.ncEdges, fd)
+	}
 	s.NotNullCols.UnionWith(fds.NotNullCols)
 	if s.HashCodeToUniqueID == nil {
 		s.HashCodeToUniqueID = fds.HashCodeToUniqueID
@@ -917,7 +973,6 @@ func (s *FDSet) AddFrom(fds *FDSet, acrossBlock bool) {
 		}
 		s.HasAggBuilt = fds.HasAggBuilt
 	}
-	s.Rule333Equiv = fds.Rule333Equiv
 }
 
 // MaxOneRow will regard every column in the fdSet as a constant. Since constant is stronger that strict FD, it will

--- a/planner/funcdep/fd_graph.go
+++ b/planner/funcdep/fd_graph.go
@@ -882,6 +882,11 @@ func (s FDSet) AllCols() FastIntSet {
 // AddFrom merges two FD sets by adding each FD from the given set to this set.
 // Since two different tables may have some column ID overlap, we better use
 // column unique ID to build the FDSet instead.
+//
+// AddFrom is commonly used to pull underlining FD up to current operator. Since
+// some ancillary factors for FD like hasAggBuild and GroupCols is strictly limited
+// into an exact scope --- that logical query block, but FD doesn't. So we should
+// clean that stuff when pulling FD across logical query blocks.
 func (s *FDSet) AddFrom(fds *FDSet, acrossBlock bool) {
 	for i := range fds.fdEdges {
 		fd := fds.fdEdges[i]

--- a/planner/funcdep/fd_graph.go
+++ b/planner/funcdep/fd_graph.go
@@ -1107,9 +1107,12 @@ func (s *FDSet) ProjectCols(cols FastIntSet) {
 					continue
 				}
 			}
-			if fd.removeColumnsToSide(fd.from) {
-				// fd.to side is empty, remove this FD.
-				continue
+			// from and to side of equiv are same, don't do trivial elimination.
+			if !fd.isEquivalence() {
+				if fd.removeColumnsToSide(fd.from) {
+					// fd.to side is empty, remove this FD.
+					continue
+				}
 			}
 		}
 

--- a/planner/funcdep/fd_graph_ported_test.go
+++ b/planner/funcdep/fd_graph_ported_test.go
@@ -65,7 +65,7 @@ func TestFuncDeps_ColsAreKey(t *testing.T) {
 	loj = *abcde
 	loj.MakeCartesianProduct(mnpq)
 	loj.AddConstants(NewFastIntSet(3))
-	loj.MakeOuterJoin(&FDSet{}, &FDSet{}, preservedCols, nullExtendedCols, nil)
+	loj.MakeOuterJoin(&FDSet{}, &FDSet{}, preservedCols, nullExtendedCols, nil, false)
 	loj.AddEquivalence(NewFastIntSet(1), NewFastIntSet(10))
 
 	testcases := []struct {

--- a/planner/funcdep/only_full_group_by_test.go
+++ b/planner/funcdep/only_full_group_by_test.go
@@ -153,6 +153,7 @@ func TestOnlyFullGroupByOldCases(t *testing.T) {
 	// classic cases
 	tk.MustQuery("select customer1.a, count(*) from customer1 left join customer2 on customer1.a=customer2.b where customer2.pk in (7,9) group by customer2.b;")
 	tk.MustQuery("select customer1.a, count(*) from customer1 left join customer2 on customer1.a=1 where customer2.pk in (7,9) group by customer2.b;")
+	tk.MustQuery("select c1.a, count(*) from customer2 c3 left join (customer1 c1 left join customer2 c2 on c1.a=c2.b) on c3.b=c1.a where c2.pk in (7,9) group by c2.b;")
 	tk.MustExec("drop view if exists customer")
 	// this left join can extend left pk to all cols.
 	tk.MustExec("CREATE algorithm=merge definer='root'@'localhost' VIEW customer as SELECT pk,a,b FROM customer1 LEFT JOIN customer2 USING (pk);")

--- a/planner/funcdep/only_full_group_by_test.go
+++ b/planner/funcdep/only_full_group_by_test.go
@@ -244,4 +244,12 @@ func TestOnlyFullGroupByOldCases(t *testing.T) {
 	require.NotNil(t, err)
 	require.Equal(t, err.Error(), "[executor:1242]Subquery returns more than 1 row")
 	tk.MustQuery("SELECT SUM(a) FROM t1 ORDER BY (SELECT COUNT(t2.a) FROM t1 AS t2);")
+
+	// fix issue 26945
+	tk.MustExec("drop table if exists t1,t2")
+	tk.MustExec("create table t1(a int, b int)")
+	tk.MustExec("create table t2(a int, b int)")
+	tk.MustExec("insert into t1 values(1,1)")
+	tk.MustExec("insert into t2 values(1,1)")
+	tk.MustQuery("select one.a from t1 one order by (select two.b from t2 two where two.a = one.b)").Check(testkit.Rows("1"))
 }

--- a/planner/funcdep/only_full_group_by_test.go
+++ b/planner/funcdep/only_full_group_by_test.go
@@ -72,13 +72,13 @@ func TestOnlyFullGroupByOldCases(t *testing.T) {
 	require.Equal(t, err.Error(), "[planner:1055]Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'test.t1.c' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by")
 	_, err = tk.Exec("SELECT DISTINCT t1.a FROM t as t1 ORDER BY t1.d LIMIT 1;")
 	require.NotNil(t, err)
-	require.Equal(t, err.Error(), "[planner:3065]Expression #1 of ORDER BY clause is not in SELECT list, references column 'test.t.d' which is not in SELECT list; this is incompatible with DISTINCT")
+	require.Equal(t, err.Error(), "[planner:3065]Expression #1 of ORDER BY clause is not in SELECT list, references column 'test.t1.d' which is not in SELECT list; this is incompatible with DISTINCT")
 	_, err = tk.Exec("SELECT DISTINCT t1.a FROM t as t1 ORDER BY t1.d LIMIT 1;")
 	require.NotNil(t, err)
-	require.Equal(t, err.Error(), "[planner:3065]Expression #1 of ORDER BY clause is not in SELECT list, references column 'test.t.d' which is not in SELECT list; this is incompatible with DISTINCT")
+	require.Equal(t, err.Error(), "[planner:3065]Expression #1 of ORDER BY clause is not in SELECT list, references column 'test.t1.d' which is not in SELECT list; this is incompatible with DISTINCT")
 	_, err = tk.Exec("SELECT (SELECT DISTINCT t1.a FROM t as t1 ORDER BY t1.d LIMIT 1) FROM t as t2;")
 	require.NotNil(t, err)
-	require.Equal(t, err.Error(), "[planner:3065]Expression #1 of ORDER BY clause is not in SELECT list, references column 'test.t.d' which is not in SELECT list; this is incompatible with DISTINCT")
+	require.Equal(t, err.Error(), "[planner:3065]Expression #1 of ORDER BY clause is not in SELECT list, references column 'test.t1.d' which is not in SELECT list; this is incompatible with DISTINCT")
 
 	// test case 7
 	tk.MustExec("drop table if exists t")


### PR DESCRIPTION
Signed-off-by: AilinKid <314806019@qq.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
order by checking can be divided as two part.
1: one is with no order by clause, which should collect info to identify whether this query is a aggregated query at all. Then judge whether a agg func in order by clause is suitable. (this can be done much earlier)
2: one is with order by clause, which require FD to check whether the item in order by clause is suitable. (this only can be done after projection is built and order item has been rewritten as an expression)

we need more test to cover, do not merge before that
### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
